### PR TITLE
Add support for custom_elements

### DIFF
--- a/lib/RssBraider.js
+++ b/lib/RssBraider.js
@@ -159,6 +159,7 @@ RssBraider.prototype.processFeed = function(feed_name, format, callback)
                 copyright           : feed.meta.copyright || null,
                 categories          : feed.meta.categories || null,
                 custom_namespaces   : feed.custom_namespaces || [],
+                custom_elements     : feed.meta.custom_elements || [],
                 no_cdata_fields     : feed.no_cdata_fields
             };
 


### PR DESCRIPTION
Currently, the system does not pass through custom elements for the feed, only for the items.  This will add support for the feed itself.